### PR TITLE
Set retro anime background only

### DIFF
--- a/components/player/background.js
+++ b/components/player/background.js
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 
 import vignette from "../../public/vignette.png";
-import bgImage from "../../public/new.jpg";
+import bgImage from "../../public/oldmecca.jpg";
 import lines from "../../public/lines.jpg";
 
 function Background() {

--- a/components/player/container.js
+++ b/components/player/container.js
@@ -272,11 +272,6 @@ function Container({ recitations, appElement }) {
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         transition={{ duration: 0.5 }}
-        style={{
-          backgroundImage: `url(${activeImage.src})`,
-          backgroundSize: "cover",
-          opacity: "0.7",
-        }}
       >
 
         {/* Player */}

--- a/config/constants.js
+++ b/config/constants.js
@@ -1,24 +1,8 @@
-import meccaone from "../public/meccanew.jpg";
-import medina from "../public/medina.jpg";
-import meccatwo from "../public/meccanew.jpg";
-import five from "../public/5.jpg";
-import seven from "../public/7.jpg";
-import eight from "../public/8.jpg";
-import nine from "../public/9.jpg";
-import ten from "../public/10.jpg";
-import glitch_1 from "../public/videos/glitch_effect_1.gif";
+import meccaRetro from "../public/oldmecca.jpg";
 import glitch_2 from "../public/videos/glitch_effect_2.gif";
-import glitch_3 from "../public/videos/glitch_effect_3.gif";
 
 export const IMAGES = [
-  meccaone,
-  medina,
-  meccatwo,
-  five,
-  seven,
-  eight,
-  nine,
-  ten,
+  meccaRetro,
 ];
 
 export const GLITCHES = [


### PR DESCRIPTION
Set a single retro-styled background image and remove all other dynamic background options.

---
<a href="https://cursor.com/background-agent?bcId=bc-907685e0-eee1-4c6e-89a2-ae97a6d6ed07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-907685e0-eee1-4c6e-89a2-ae97a6d6ed07">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

