### PR TITLE
Fix vercel function runtime version error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "tailwindcss": "^2.2.15"
   },
   "engines": {
-    "node": "22.x"
+    "node": "20.x"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
+  "version": 2,
   "functions": {
     "**": {
-      "runtime": "nodejs22.x"
+      "runtime": "nodejs20.x"
     }
   }
 }


### PR DESCRIPTION
Update Vercel configuration and Node.js version to resolve runtime validation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-e635701b-fff8-4a8c-bfe4-de3a9d1334a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e635701b-fff8-4a8c-bfe4-de3a9d1334a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

